### PR TITLE
update to v0.2.2

### DIFF
--- a/moneykit/api_client.py
+++ b/moneykit/api_client.py
@@ -80,7 +80,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "OpenAPI-Generator/0.2.1/python"
+        self.user_agent = "OpenAPI-Generator/0.2.2/python"
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/moneykit/configuration.py
+++ b/moneykit/configuration.py
@@ -405,7 +405,7 @@ class Configuration:
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: 2023-02-18\n"
-            "SDK Package Version: 0.2.1".format(env=sys.platform, pyversion=sys.version)
+            "SDK Package Version: 0.2.2".format(env=sys.platform, pyversion=sys.version)
         )
 
     def get_host_settings(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "moneykit"
-version = "0.2.1"
+version = "0.2.2"
 description = "MoneyKit API"
 authors = ["OpenAPI Generator Community <team@openapitools.org>"]
 license = "NoLicense"


### PR DESCRIPTION
Only for parity with Ruby, which had to go to 0.2.2 because 0.2.1 was broken and it seemed impossible to update the gem at https://rubygems.org/gems/moneykit.