### PR TITLE
update to PEP 517

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
-        with:
-            version: 1.6.1
 
       - name: Install dependencies
         run: |
@@ -41,7 +39,7 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
-          poetry build
+          poetry build --clean
           ls -lh dist
           twine check --strict dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,13 @@
-[tool.poetry]
+[project]
 name = "moneykit"
 version = "0.2.2"
 description = "MoneyKit API"
-authors = ["OpenAPI Generator Community <team@openapitools.org>"]
-license = "NoLicense"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "MoneyKit API"]
-include = ["moneykit/py.typed"]
+requires-python = ">=3.8"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
 pydantic = ">=2"


### PR DESCRIPTION
Reverting to latest poetry and fixing pyproject (which comes from moneykit-openapi, will fix there also) to conform to PEP 517, which appears to be the problem with pushing to pypi.